### PR TITLE
12 get api articles article id comment count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -72,6 +72,17 @@ describe ( "app" , () => {
         .toBe( 100 ) ;
         expect( body.article.article_img_url )
         .toBe( "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700" ) ;
+        expect( body.article.comment_count )
+        .toBe ( 11 ) ;
+      }) ;
+    }) ;
+    test( "status 200: should handle articles with 0 comments" , () => {
+      return request( app )
+      .get( "/api/articles/2" )
+      .expect( 200 )
+      .then( ( { body } ) => {
+        expect( body.article.comment_count )
+        .toBe ( 0 ) ;
       }) ;
     }) ;
     test( "status 404: returned with error message for valid but non-existent id" , () => {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -16,7 +16,7 @@ exports.getArticleById = ( req , res , next ) => {
 } ;
 
 exports.getArticles = ( req , res , next ) => {
-  const { topic } = req.query;
+  const { topic } = req.query ;
   selectArticles( topic )
   .then( ( articles ) => {
     res

--- a/endpoints.json
+++ b/endpoints.json
@@ -39,7 +39,8 @@
         "body": "Text from the article..",
         "created_at": "2018-05-30T15:59:13.341Z",
         "votes": 0,
-        "article_img_url": "https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?w=700&h=700",
+        "comment_count": 6
       }
     }
   },

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -2,6 +2,15 @@ const db = require( "../db/connection" ) ;
 const { checkExists } = require( "./utils.models" ) ;
 
 exports.selectArticleById = ( article_id ) => {
+
+
+  const commentCountQuery = `
+    SELECT COUNT(*)::int AS comment_count
+    FROM comments
+    WHERE article_id = $1;
+  `;
+
+
   return db
     .query( "SELECT * FROM articles WHERE article_id = $1;" , [ article_id ] )
     .then( ( { rows } ) => {
@@ -9,7 +18,18 @@ exports.selectArticleById = ( article_id ) => {
       if ( !article ) {
         return Promise.reject( { status : 404 , msg : "article does not exist" })
       }
-      return article;
+
+      return db
+      .query(
+        `SELECT COUNT(*)::int AS comment_count
+        FROM comments
+        WHERE article_id = $1;` ,
+        [ article_id ] 
+      )
+      .then(( commentCountResult ) => {
+        article.comment_count = commentCountResult.rows[ 0 ].comment_count ;
+        return article ;
+      })
     }) ;
 } ;
 

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -3,34 +3,22 @@ const { checkExists } = require( "./utils.models" ) ;
 
 exports.selectArticleById = ( article_id ) => {
 
-
-  const commentCountQuery = `
-    SELECT COUNT(*)::int AS comment_count
-    FROM comments
-    WHERE article_id = $1;
-  `;
-
-
   return db
-    .query( "SELECT * FROM articles WHERE article_id = $1;" , [ article_id ] )
-    .then( ( { rows } ) => {
-      const article = rows[ 0 ]
-      if ( !article ) {
-        return Promise.reject( { status : 404 , msg : "article does not exist" })
-      }
-
-      return db
-      .query(
-        `SELECT COUNT(*)::int AS comment_count
-        FROM comments
-        WHERE article_id = $1;` ,
-        [ article_id ] 
-      )
-      .then(( commentCountResult ) => {
-        article.comment_count = commentCountResult.rows[ 0 ].comment_count ;
-        return article ;
-      })
-    }) ;
+  .query(
+    `SELECT articles.article_id, articles.title, articles.topic, articles.author, articles.body, articles.created_at, articles.votes, articles.article_img_url, COUNT(comments.comment_id)::int AS comment_count
+    FROM articles
+    LEFT JOIN comments ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id;` , 
+    [ article_id ] 
+  )
+  .then( ( { rows } ) => {
+    const article = rows[ 0 ]
+    if ( !article ) {
+      return Promise.reject( { status : 404 , msg : "article does not exist" } ) ;
+    }
+    return article ;
+  }) ;
 } ;
 
 exports.selectArticles = async ( topic ) => {


### PR DESCRIPTION
extended selectArticleById models/articles.models.js to return comment_count

endpoint details for added to endpoints.json

tests for various 200, 400, and 404 response cases of endpoint added to __tests__/app.test.js